### PR TITLE
Add Ubuntu 26.04 base image variant and CI matrix entry

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE_TAG: [22.04, 24.04]
+        IMAGE_TAG: [22.04, 24.04, 26.04]
     steps:
       - uses: actions/checkout@v4
       - name: docker build
@@ -40,7 +40,7 @@ jobs:
     needs: check-all-base
     strategy:
       matrix:
-        IMAGE_TAG: [22.04, 24.04]
+        IMAGE_TAG: [22.04, 24.04, 26.04]
     steps:
       - name: docker push
         uses: kubasejdak-org/docker-push-action@main

--- a/base/26.04/Dockerfile
+++ b/base/26.04/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:26.04
+LABEL maintainer="Kuba Sejdak (kuba.sejdak@gmail.com)"
+
+# Settings.
+ARG USERNAME=ubuntu
+
+ENV TZ=Europe/Warsaw
+
+# Prepare APT for installing packages.
+RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo "APT::Install-Recommends \"false\";" >> /etc/apt/apt.conf && \
+    echo "APT::Install-Suggests \"false\";" >> /etc/apt/apt.conf && \
+    apt update && \
+    apt upgrade -y && \
+    apt install -y tzdata && \
+    \
+    # Set default user permissions.
+    apt install -y sudo && \
+    echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL >> /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME}
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+ENV HISTFILE=""
+ENV LC_ALL=en_US.UTF-8
+ENV PATH=/home/${USERNAME}/.local/bin:$PATH
+ENV USER=${USERNAME}
+
+# Configure locales.
+RUN sudo apt install -y locales && \
+    sudo locale-gen en_US.UTF-8 && \
+    \
+    # Install git and SSH client.
+    sudo apt install -y git openssh-client && \
+    sudo git config --system --add safe.directory '*' && \
+    \
+    # Install additional packages.
+    sudo apt install -y bash-completion bc ca-certificates curl file less lsof openssh-client tmux tree vim wget jq && \
+    \
+    # Create common project directories.
+    sudo mkdir -p -m 777 /var/log/ks


### PR DESCRIPTION
### Motivation
- Extend the existing base image hierarchy to include an Ubuntu `26.04` variant so derived images can target the newer distro release.
- Ensure CI builds and pushes the new `26.04` base tag automatically by updating the workflows.

### Description
- Add a new `base/26.04/Dockerfile` that mirrors the existing base variants and uses `FROM ubuntu:26.04` as the parent image.
- Keep the same user, locale, and package setup as other base variants to maintain consistency across versions.
- Update `.github/workflows/base.yml` to include `26.04` in the `IMAGE_TAG` matrix for both build and deploy jobs.

### Testing
- Run `git diff --check` which produced no issues and confirmed the changes are syntactically clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db73d1b5dc8326bc5cbc6192284bae)