### PR TITLE
Add Ubuntu 26.04 variants for non-base images and update CI matrices

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE_TAG: [24.04]
+        IMAGE_TAG: [24.04, 26.04]
     steps:
       - uses: actions/checkout@v4
       - name: docker build
@@ -40,7 +40,7 @@ jobs:
     needs: check-all-ansible
     strategy:
       matrix:
-        IMAGE_TAG: [24.04]
+        IMAGE_TAG: [24.04, 26.04]
     steps:
       - name: docker push
         uses: kubasejdak-org/docker-push-action@main

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE_TAG: [22.04, 24.04]
+        IMAGE_TAG: [22.04, 24.04, 26.04]
     steps:
       - uses: actions/checkout@v4
       - name: docker build
@@ -40,7 +40,7 @@ jobs:
     needs: check-all-doxygen
     strategy:
       matrix:
-        IMAGE_TAG: [22.04, 24.04]
+        IMAGE_TAG: [22.04, 24.04, 26.04]
     steps:
       - name: docker push
         uses: kubasejdak-org/docker-push-action@main

--- a/.github/workflows/mkdocs-material.yml
+++ b/.github/workflows/mkdocs-material.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE_TAG: [24.04]
+        IMAGE_TAG: [24.04, 26.04]
     steps:
       - uses: actions/checkout@v4
       - name: docker build
@@ -40,7 +40,7 @@ jobs:
     needs: check-all-mkdocs-material
     strategy:
       matrix:
-        IMAGE_TAG: [24.04]
+        IMAGE_TAG: [24.04, 26.04]
     steps:
       - name: docker push
         uses: kubasejdak-org/docker-push-action@main

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE_TAG: [22.04, 24.04]
+        IMAGE_TAG: [22.04, 24.04, 26.04]
     steps:
       - uses: actions/checkout@v4
       - name: docker build
@@ -40,7 +40,7 @@ jobs:
     needs: check-all-valgrind
     strategy:
       matrix:
-        IMAGE_TAG: [22.04, 24.04]
+        IMAGE_TAG: [22.04, 24.04, 26.04]
     steps:
       - name: docker push
         uses: kubasejdak-org/docker-push-action@main

--- a/ansible/26.04/Dockerfile
+++ b/ansible/26.04/Dockerfile
@@ -1,0 +1,17 @@
+FROM kubasejdak/base:26.04
+
+# Settings.
+ARG ANSIBLE_VERSION=13.3.0
+
+# Install python3.
+RUN sudo apt update && \
+    sudo apt install -y python-is-python3 python3 python3-pip python3-venv && \
+    sudo -H pip config set global.break-system-packages true && \
+    \
+    # Install ansible and related tools.
+    sudo -H pip install ansible==${ANSIBLE_VERSION} ansible-lint cryptography passlib && \
+    \
+    # Cleanup image.
+    sudo apt autoremove -y && \
+    sudo apt clean && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/doxygen/26.04/Dockerfile
+++ b/doxygen/26.04/Dockerfile
@@ -1,0 +1,10 @@
+FROM kubasejdak/base:26.04
+
+# Install doxygen and graphviz.
+RUN sudo apt update && \
+    sudo apt install -y doxygen graphviz && \
+    \
+    # Cleanup image.
+    sudo apt autoremove -y && \
+    sudo apt clean && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/mkdocs-material/26.04/Dockerfile
+++ b/mkdocs-material/26.04/Dockerfile
@@ -1,0 +1,25 @@
+FROM kubasejdak/base:26.04
+
+# Settings.
+ARG MKDOCS_MATERIAL_VERSION=9.7.3
+
+# Install python3.
+RUN sudo apt update && \
+    sudo apt install -y python-is-python3 python3 python3-pip python3-venv && \
+    sudo -H pip config set global.break-system-packages true && \
+    \
+    # Install material for mkdocs and related tools.
+    sudo -H pip install mkdocs-material[imaging]==${MKDOCS_MATERIAL_VERSION} \
+    mkdocs-drawio \
+    mkdocs-macros-plugin \
+    mkdocs-mermaid2-plugin \
+    mkdocs-redirects \
+    mkdocs-rss-plugin \
+    mike \
+    mkdoxy && \
+    sudo apt install -y doxygen libcairo2 python3-pyparsing python3-six && \
+    \
+    # Cleanup image.
+    sudo apt autoremove -y && \
+    sudo apt clean && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/valgrind/26.04/Dockerfile
+++ b/valgrind/26.04/Dockerfile
@@ -1,0 +1,10 @@
+FROM kubasejdak/base:26.04
+
+# Install valgrind.
+RUN sudo apt update && \
+    sudo apt install -y valgrind && \
+    \
+    # Cleanup image.
+    sudo apt autoremove -y && \
+    sudo apt clean && \
+    sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Motivation
- Provide Ubuntu `26.04` variants for images that previously only targeted `22.04`/`24.04` so they match the existing `base:26.04` image and enable builds for the new platform.

### Description
- Add new Dockerfiles `ansible/26.04/Dockerfile`, `doxygen/26.04/Dockerfile`, `mkdocs-material/26.04/Dockerfile`, and `valgrind/26.04/Dockerfile` that start with `FROM kubasejdak/base:26.04` and follow each image's existing installation pattern.
- Keep per-image package/tool installation and cleanup steps identical to the `24.04` variants to preserve behavior across tags.
- Update CI workflow matrices in `.github/workflows/ansible.yml`, `.github/workflows/doxygen.yml`, `.github/workflows/mkdocs-material.yml`, and `.github/workflows/valgrind.yml` to include `26.04` in both build and deploy `IMAGE_TAG` matrices.

### Testing
- Ran `git diff --check` to validate there are no whitespace/errors reported by the diff check and it succeeded.
- Ran `git status --short` to verify the expected files were added/modified and it returned the expected changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8546d6e08326a8ef1930d971a921)