### PR TITLE
Bump mkdocs-material and ansible versions in Dockerfiles

### DIFF
--- a/ansible/24.04/Dockerfile
+++ b/ansible/24.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM kubasejdak/base:24.04
 
 # Settings.
-ARG ANSIBLE_VERSION=13.3.0
+ARG ANSIBLE_VERSION=13.5.0
 
 # Install python3.
 RUN sudo apt update && \

--- a/ansible/26.04/Dockerfile
+++ b/ansible/26.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM kubasejdak/base:26.04
 
 # Settings.
-ARG ANSIBLE_VERSION=13.3.0
+ARG ANSIBLE_VERSION=13.5.0
 
 # Install python3.
 RUN sudo apt update && \

--- a/mkdocs-material/24.04/Dockerfile
+++ b/mkdocs-material/24.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM kubasejdak/base:24.04
 
 # Settings.
-ARG MKDOCS_MATERIAL_VERSION=9.7.3
+ARG MKDOCS_MATERIAL_VERSION=9.7.6
 
 # Install python3.
 RUN sudo apt update && \

--- a/mkdocs-material/26.04/Dockerfile
+++ b/mkdocs-material/26.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM kubasejdak/base:26.04
 
 # Settings.
-ARG MKDOCS_MATERIAL_VERSION=9.7.3
+ARG MKDOCS_MATERIAL_VERSION=9.7.6
 
 # Install python3.
 RUN sudo apt update && \


### PR DESCRIPTION
### Motivation
- Keep the container images up-to-date by using the current releases of `mkdocs-material` and `ansible` from PyPI. 
- Ensure documentation and automation tool images remain reproducible and receive the latest fixes and features. 

### Description
- Update `ARG MKDOCS_MATERIAL_VERSION` from `9.7.3` to `9.7.6` in `mkdocs-material/24.04/Dockerfile` and `mkdocs-material/26.04/Dockerfile`. 
- Update `ARG ANSIBLE_VERSION` from `13.3.0` to `13.5.0` in `ansible/24.04/Dockerfile` and `ansible/26.04/Dockerfile`. 
- Preserve the existing package installation and cleanup logic; this change only adjusts the version arguments. 

### Testing
- Queried PyPI JSON for `mkdocs-material` and `ansible` and confirmed the upstream versions are `9.7.6` and `13.5.0`, respectively, and the check succeeded. 
- Applied the automated text-replacement script to update the four Dockerfiles and confirmed the files contain the new `ARG` values. 
- Verified the repository diffs reflect only the intended version changes and no other regressions were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc12605cdc83268c4f2f0d6effab86)